### PR TITLE
Make filter match exactly

### DIFF
--- a/src/app/services/search/search.service.ts
+++ b/src/app/services/search/search.service.ts
@@ -19,7 +19,7 @@ export class SearchService {
 
   public getjobs(filter?: any, params: any = {}, count: number = 30): Observable<any> {
     let queryArray: string[] = [];
-    params.query = `(isOpen:1) AND (isDeleted:0)${this.formatAdditionalCriteria(true)}${this.formatFilter(filter, true)}`;
+    params.where = `(isOpen=TRUE AND isDeleted=FALSE)${this.formatAdditionalCriteria(false)}${this.formatFilter(filter, false)}`;
     params.fields = SettingsService.settings.service.fields;
     params.count = count;
     params.sort = SettingsService.settings.additionalJobCriteria.sort;
@@ -30,7 +30,7 @@ export class SearchService {
     }
     let queryString: string = queryArray.join('&');
 
-    return this.http.get(`${this.baseUrl}/search/JobOrder?${queryString}`);
+    return this.http.get(`${this.baseUrl}/query/JobOrder?${queryString}`);
   }
 
   public openJob(id: string | number): Observable<any> {

--- a/src/app/sidebar/sidebar-filter/sidebar-filter.component.ts
+++ b/src/app/sidebar/sidebar-filter/sidebar-filter.component.ts
@@ -131,7 +131,7 @@ export class SidebarFilterComponent implements OnChanges {
           this.lastSetValue = API.getActiveValue();
           if (API.getActiveValue()) {
           values = API.getActiveValue().map((value: number) => {
-            return `customText3{?^^equals}${value}`;
+            return `customText3{?^^equals}{?^^delimiter}${value}{?^^delimiter}`;
           });
           }
           this.checkboxFilter.emit(values);


### PR DESCRIPTION
Updated getJobs to use /query backend instead of search to enable exact matching with filters.
Fixes #1

## Additions / Removals

- removed call to /search endpoint
- added call to /query endpoint
- added missing delimiters to customText3 filters

## Testing

- tested the rest of the filters and the keyword search for any unwanted changes -> They still work the same

## Screenshots
![grafik](https://user-images.githubusercontent.com/92150718/203673977-027e1f34-ddc4-4261-a5ab-1341eb2a1d0e.png)